### PR TITLE
add 'published' column to posts

### DIFF
--- a/db/migrate/20200202033706_add_published_to_posts.rb
+++ b/db/migrate/20200202033706_add_published_to_posts.rb
@@ -1,0 +1,5 @@
+class AddPublishedToPosts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :posts, :published, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_26_024735) do
+ActiveRecord::Schema.define(version: 2020_02_02_033706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2020_01_26_024735) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "blog_id"
+    t.boolean "published"
   end
 
   create_table "snippets", force: :cascade do |t|


### PR DESCRIPTION
related issues: #14, https://github.com/codepitaka/pitaka-web/issues/6, https://github.com/codepitaka/pitaka-web/issues/8

I added `published` (boolean) column to `posts` table with commands below.

```
rails g migration add_published_to_posts published:boolean
rake db:migrate
```